### PR TITLE
Frontend error while refresh all trees after recycled bin #6107

### DIFF
--- a/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
+++ b/bundles/AdminBundle/Resources/public/js/pimcore/settings/recyclebin.js
@@ -246,25 +246,18 @@ pimcore.settings.recyclebin = Class.create({
         if (offset == ids.length) {
             // refresh all trees
             try {
-                if (pimcore.globalmanager.get("layout_document_tree").tree.rendered) {
-                    var tree = pimcore.globalmanager.get("layout_document_tree").tree;
-                    tree.getStore().load({
-                        node: tree.getRootNode()
-                    });
-                }
-                if (pimcore.globalmanager.get("layout_asset_tree").tree.rendered) {
-                    var tree = pimcore.globalmanager.get("layout_asset_tree").tree;
-                    tree.getStore().load({
-                        node: tree.getRootNode()
-                    });
+                var treeNames = ["document_tree", "asset_tree", "object_tree"];
 
-                }
-                if (pimcore.globalmanager.get("layout_object_tree").tree.rendered) {
-                    var tree = pimcore.globalmanager.get("layout_object_tree").tree;
-                    tree.getStore().load({
-                        node: tree.getRootNode()
-                    });
-                }
+                treeNames.forEach(function (treeName) {
+                    var treeLayout = pimcore.globalmanager.get("layout_" + treeName);
+
+                    if (treeLayout && treeLayout.tree.rendered) {
+                        var tree = treeLayout.tree;
+                        tree.getStore().load({
+                            node: tree.getRootNode()
+                        });
+                    }
+                });
             }
             catch (e) {
                 console.log(e);


### PR DESCRIPTION
## Changes in this pull request 
Fix the TypeError while recyle a object from bin

# Resolves 
```
TypeError: Cannot read property 'rendered' of undefined
    at klass.doRestore (script-proxy?scripts=minified_javascript_core_5b0dd417454df3797f350320a8b61740.js&_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:21354)
    at klass.<anonymous> (script-proxy?scripts=minified_javascript_core_5b0dd417454df3797f350320a8b61740.js&_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:21389)
    at Object.callback (ext-all.js?_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:22)
    at E.onComplete (ext-all.js?_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:22)
    at E.onStateChange (ext-all.js?_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:22)
    at XMLHttpRequest.t (ext-all.js?_dc=c49d5fbce4cee1eb2a6d6fb619de3e45fc5e5532:22)
```